### PR TITLE
[DOT-1259] bump checkout and use default tokens

### DIFF
--- a/.github/workflows/update-cotw.yml
+++ b/.github/workflows/update-cotw.yml
@@ -4,13 +4,12 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.ACTIONS_GITHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - name: 'Checkout docs-update-cotw'
+        uses: actions/checkout@v5
+      - name: 'Checkout docs repo'
+        uses: actions/checkout@v5
         with:
           repository: 'Codecademy/docs'
-          token: ${{ secrets.ACTIONS_GITHUB_TOKEN }}
           path: 'docs'
       - uses: actions/setup-node@v4
         with:
@@ -38,4 +37,5 @@ jobs:
 
 on:
   schedule:
-  - cron: '0 13 * * 0' # every sunday at 1:00pm UTC
+    - cron: '0 13 * * 0' # every sunday at 1:00pm UTC
+  workflow_dispatch:


### PR DESCRIPTION
https://skillsoftdev.atlassian.net/browse/DOT-1259

I've added the ability to launch this action manually for easier debugging.  According to the `checkout/v5` docs we _should_ be able to checkout `Codecademy/docs` from this repo as docs is a public repo. I've removed the github token parameters from both checkout calls in case that's what was causing the issue (the `checkout/v5` action now defaults to something reasonable that _should_ work). Lots of "shoulds" here, I know!