### PR TITLE
use org token for docs repo checkout

### DIFF
--- a/.github/workflows/update-cotw.yml
+++ b/.github/workflows/update-cotw.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           repository: 'Codecademy/docs'
           path: 'docs'
+          token: ${{ secrets.ACTIONS_GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           cache: 'yarn'


### PR DESCRIPTION
forgot that we _do_ need the org token for pushing to the docs repo